### PR TITLE
#2: queue and handle M300 commands async

### DIFF
--- a/octoprint_pwmbuzzer/buzzers.py
+++ b/octoprint_pwmbuzzer/buzzers.py
@@ -1,0 +1,96 @@
+from abc import ABC, abstractmethod
+import logging
+
+try:
+    import RPi.GPIO as GPIO
+    GPIO_AVAILABLE = True
+except ImportError:
+    GPIO_AVAILABLE = False
+
+class Buzzer(ABC):
+    def __init__(self):
+        pass
+
+    @abstractmethod
+    def is_enabled():
+        pass
+
+    @abstractmethod
+    def start(self, frequency):
+        pass
+
+    @abstractmethod
+    def stop(self):
+        pass
+
+class HardwareBuzzer(Buzzer):
+    def __init__(self, enabled, pin, duty_cycle):
+        self._logger = logging.getLogger(__name__+"."+self.__class__.__name__)
+
+        self.pwm = None
+        self.set_settings(enabled, pin, duty_cycle)
+
+    def Available():
+        return GPIO_AVAILABLE
+
+    def set_settings(self, enabled, pin, duty_cycle):
+        if enabled is not None:
+            self._enabled = enabled
+        if pin is not None:
+            self._pin = pin
+        if duty_cycle is not None:
+            self._duty_cycle = duty_cycle
+
+        self._logger.info("HardwareBuzzer set to enabled {self._enabled} pin {self._pin} with duty cycle {self._duty_cycle}".format(**locals()))
+
+    def is_enabled(self):
+        return HardwareBuzzer.Available() and self._enabled
+
+    def start(self, frequency):
+        if not self.is_enabled():
+            return
+
+        self._logger.debug("🎵 starting tone... {frequency}Hz (using BCM pin {self._pin} at {self._duty_cycle}% duty cycle)".format(**locals()))
+        GPIO.setmode(GPIO.BCM)
+        GPIO.setup(self._pin, GPIO.OUT)
+        self.pwm = GPIO.PWM(self._pin, frequency)
+        self.pwm.start(self._duty_cycle)
+
+    def stop(self):
+        # Stop hardware tone regardless of feature enablement (don't leave a tone running)
+        if not HardwareBuzzer.Available():
+            return
+
+        if self.pwm is not None:
+            self.pwm.stop()
+            self.pwm = None
+            GPIO.cleanup()
+        elif self._enabled:
+            self._logger.warn("Hardware buzzer is enabled, but reference to PWM buzzer wasn't found when trying to stop the tone.")
+
+class SoftwareBuzzer(Buzzer):
+    def __init__(self, messageFunc, enabled):
+        self._logger = logging.getLogger(__name__+"."+self.__class__.__name__)
+
+        self._sendMessageImplementation = messageFunc
+        self.set_settings(enabled)
+
+    def set_settings(self, enabled):
+        if enabled is not None:
+            self._enabled = enabled
+
+        self._logger.info("SoftwareBuzzer set to enabled {self._enabled}".format(**locals()))
+
+    def is_enabled(self):
+        return self._enabled
+
+    def start(self, frequency):
+        self._sendMessageImplementation({
+            "action": "software_tone_start",
+            "frequency": frequency,
+        })
+
+    def stop(self):
+        self._sendMessageImplementation({
+            "action": "software_tone_stop",
+        })

--- a/octoprint_pwmbuzzer/buzzers.py
+++ b/octoprint_pwmbuzzer/buzzers.py
@@ -27,7 +27,7 @@ class HardwareBuzzer(Buzzer):
     def __init__(self, enabled, pin, duty_cycle):
         self._logger = logging.getLogger(__name__+"."+self.__class__.__name__)
 
-        self.pwm = None
+        self._pwm = None
         self.set_settings(enabled, pin, duty_cycle)
 
     def Available():
@@ -35,11 +35,11 @@ class HardwareBuzzer(Buzzer):
 
     def set_settings(self, enabled, pin, duty_cycle):
         if enabled is not None:
-            self._enabled = enabled
+            self._enabled = bool(enabled)
         if pin is not None:
-            self._pin = pin
+            self._pin = int(pin)
         if duty_cycle is not None:
-            self._duty_cycle = duty_cycle
+            self._duty_cycle = int(duty_cycle)
 
         self._logger.info("HardwareBuzzer set to enabled {self._enabled} pin {self._pin} with duty cycle {self._duty_cycle}".format(**locals()))
 
@@ -53,17 +53,17 @@ class HardwareBuzzer(Buzzer):
         self._logger.debug("🎵 starting tone... {frequency}Hz (using BCM pin {self._pin} at {self._duty_cycle}% duty cycle)".format(**locals()))
         GPIO.setmode(GPIO.BCM)
         GPIO.setup(self._pin, GPIO.OUT)
-        self.pwm = GPIO.PWM(self._pin, frequency)
-        self.pwm.start(self._duty_cycle)
+        self._pwm = GPIO.PWM(self._pin, frequency)
+        self._pwm.start(self._duty_cycle)
 
     def stop(self):
         # Stop hardware tone regardless of feature enablement (don't leave a tone running)
         if not HardwareBuzzer.Available():
             return
 
-        if self.pwm is not None:
-            self.pwm.stop()
-            self.pwm = None
+        if self._pwm is not None:
+            self._pwm.stop()
+            self._pwm = None
             GPIO.cleanup()
         elif self._enabled:
             self._logger.warn("Hardware buzzer is enabled, but reference to PWM buzzer wasn't found when trying to stop the tone.")
@@ -77,7 +77,7 @@ class SoftwareBuzzer(Buzzer):
 
     def set_settings(self, enabled):
         if enabled is not None:
-            self._enabled = enabled
+            self._enabled = bool(enabled)
 
         self._logger.info("SoftwareBuzzer set to enabled {self._enabled}".format(**locals()))
 

--- a/octoprint_pwmbuzzer/templates/settings/composer.jinja2
+++ b/octoprint_pwmbuzzer/templates/settings/composer.jinja2
@@ -15,12 +15,6 @@
     {% endfor %}
 {%- endmacro %}
 
-<div class="alert alert-block" data-bind="visible: hw_unsaved_settings">
-    <strong>Warning: </strong>
-    You changed the Hardware Buzzer settings but have not yet saved your changes.
-    Please save your changes before playing your composition below to ensure it works properly.
-</div>
-
 <div class="control-group" data-bind="using: composer">
     <div class="piano input-block-level">
         {{ pianooctave(3) }}

--- a/octoprint_pwmbuzzer/templates/settings/events.jinja2
+++ b/octoprint_pwmbuzzer/templates/settings/events.jinja2
@@ -27,12 +27,6 @@
 </div>
 {%- endmacro %}
 
-<div class="alert alert-block" data-bind="visible: hw_unsaved_settings">
-    <strong>Warning: </strong>
-    You changed the Hardware Buzzer settings but have not yet saved your changes.
-    Please save your changes before testing any presets or files below to ensure it works properly.
-</div>
-
 {% for group in plugin_pwmbuzzer_supported_events -%}
     <legend>{{ _(group.category) }}</legend>
     {% for event in group.events -%}

--- a/octoprint_pwmbuzzer/tones.py
+++ b/octoprint_pwmbuzzer/tones.py
@@ -1,0 +1,75 @@
+from enum import Enum
+from queue import SimpleQueue
+from threading import Thread
+import time
+import logging
+
+INTER_NOTE_PAUSE_DURATION = 0.01
+
+class ToneCommand(Enum):
+    STOP = 0
+    START = 1
+    PLAY = 2
+    REST = 3
+
+class Tone():
+    def __init__(self, command, buzzers = [], frequency = None, duration = None):
+        self._logger = logging.getLogger(__name__+"."+self.__class__.__name__)
+        self.command = command
+        self.buzzers = buzzers
+        self.frequency = frequency
+        self.duration = duration
+
+    def exec(self):
+        if len(self.buzzers) < 1:
+            self._logger.warn("{0} executed with no attached buzzers, ignoring.".format(self))
+            return
+
+        if self.command is ToneCommand.START:
+            for buzzer in self.buzzers:
+                buzzer.start(self.frequency)
+        elif self.command is ToneCommand.STOP:
+            for buzzer in self.buzzers:
+                buzzer.stop()
+        elif self.command is ToneCommand.PLAY:
+            for buzzer in self.buzzers:
+                buzzer.start(self.frequency)
+            time.sleep(self.duration / 1000)
+            for buzzer in self.buzzers:
+                buzzer.stop()
+
+            # Pause briefly between notes
+            time.sleep(INTER_NOTE_PAUSE_DURATION)
+        elif self.command is ToneCommand.REST:
+            time.sleep(self.duration / 1000)
+
+    def __repr__(self):
+        if self.command in [ToneCommand.START, ToneCommand.PLAY]:
+            return "%s (%s %.3fHz)" % (self.__class__.__name__, self.command.name, self.frequency)
+        else:
+            return "%s (%s)" % (self.__class__.__name__, self.command.name)
+
+class ToneQueue():
+    def __init__(self):
+        self._logger = logging.getLogger(__name__+"."+self.__class__.__name__)
+        self._queue = SimpleQueue()
+        self._thread = None
+
+    def add(self, tone):
+        self._logger.debug("adding to the queue: {0}".format(tone))
+        self._queue.put(tone)
+        self._runQueue()
+
+    def _runQueue(self):
+        if self._thread is not None and self._thread.is_alive():
+            return
+
+        self._thread = Thread(target=self._worker)
+        self._thread.start()
+        self._logger.debug("forked a thread: {0}".format(self._thread.ident))
+
+    def _worker(self):
+        while not self._queue.empty():
+            tone = self._queue.get()
+            self._logger.debug("pulled from the queue to be executed: {0}".format(tone))
+            tone.exec()


### PR DESCRIPTION
## Description

This change ensures we don't block the main thread in OctoPrint when handling and playing tones from M300 commands.  I refactored everything a bit to do the following:

- Separated the functionality of buzzers into their own classes for handling the start & stop of tones.
- Added classes to wrap the concept of tones (play, rest, etc.) and decouple it from the buzzers.
- Added a queue for adding tones as they are encountered.  When the queue is populated a new thread is spun up so that these are now played asynchronously.
- Removed overrides for testing tones from the settings panels... now when you modify settings it will temporarily update those of the buzzers to act accordingly.  This means testing tones or using the composer should also work without having to first save your settings.

## Test Plan

- [x] verified general functionality of M300 commands with hardware, software, both, or neither buzzers enabled
- [x] verified functionality of settings panels with hardware, software, both, or neither buzzers enabled
- [x] confirmed tones are no longer blocking print jobs (e.g. printing completes even if we queue up more M300 commands)
