### PR TITLE
#4: make file parsing non-blocking

### DIFF
--- a/octoprint_pwmbuzzer/__init__.py
+++ b/octoprint_pwmbuzzer/__init__.py
@@ -12,15 +12,9 @@ from octoprint_pwmbuzzer import (
     tunes,
     events,
     tones,
-    buzzers
+    buzzers,
+    files
 )
-
-REGEX_LINE_HAS_M300_COMMAND = r"^[^;]*M300"
-REGEX_FILE_HAS_ANY_M300_COMMAND = r"[m|M]300"
-REGEX_FILE_HAS_UNCOMMENTED_M300_COMMAND = r"(^[^;]*[m|M]300)|(\n[^;]*[m|M]300)"
-M300_ANALYSIS_KEY = "m300analysis"
-
-FILE_PARSE_WARN_AFTER = 3
 
 class PwmBuzzerPlugin(
     octoprint.plugin.SettingsPlugin,
@@ -36,6 +30,13 @@ class PwmBuzzerPlugin(
         self.tones = tones.ToneQueue()
         self.hw_buzzer = None
         self.sw_buzzer = None
+
+        self._m300_parser = None
+
+    def _get_m300_parser(self):
+        if self._m300_parser is None:
+            self._m300_parser = files.M300FileParsingQueue(self._file_manager)
+        return self._m300_parser
 
     # Called when injections are complete
     def initialize(self):
@@ -82,52 +83,8 @@ class PwmBuzzerPlugin(
 
     ##~~ TemplatePlugin mixin
 
-    def _filter_m300_files(self, file):
-        if file["type"] != "machinecode":
-            return False
-
-        id = file["path"]
-        fileHash = "default"
-        if "hash" in file:
-            fileHash = file["hash"]
-
-        if M300_ANALYSIS_KEY in file and fileHash in file[M300_ANALYSIS_KEY]:
-            return file[M300_ANALYSIS_KEY][fileHash]
-
-        path = self._file_manager.path_on_disk("local", id)
-        regex = re.compile(REGEX_FILE_HAS_ANY_M300_COMMAND)
-        with open(path, "r") as fileaccess:
-            text = fileaccess.read()
-            if re.search(regex, text):
-                regexu = re.compile(REGEX_FILE_HAS_UNCOMMENTED_M300_COMMAND)
-                if re.search(regexu, text):
-                    self._file_manager._storage_managers["local"].set_additional_metadata(path=id, key=M300_ANALYSIS_KEY, data=dict([(fileHash, True)]), merge=True)
-                    return True
-
-        self._file_manager._storage_managers["local"].set_additional_metadata(path=id, key=M300_ANALYSIS_KEY, data=dict([(fileHash, False)]), merge=True)
-        return False
-
-    def _recurse_files(self, folder, filelist = dict()):
-        for key in folder["children"]:
-            if folder["children"][key]["type"] == "folder":
-               self._recurse_files(folder["children"][key], filelist)
-            else:
-                filelist[folder["children"][key]["path"]] = folder["children"][key]
-
     def get_template_vars(self):
-        start_time = time.time()
-        tune_files = dict()
-        all_files = self._file_manager._storage_managers["local"].list_files(filter=self._filter_m300_files)
-        if all_files is not None:
-            for key in all_files:
-                if all_files[key]["type"] == "folder":
-                    self._recurse_files(all_files[key], tune_files) 
-                else:
-                    tune_files[all_files[key]["path"]] = all_files[key]
-
-        elapsed = time.time() - start_time
-        if elapsed > FILE_PARSE_WARN_AFTER:
-            self._logger.warn("Parsing .gcode files for M300 content took %s seconds at startup" % elapsed)
+        tune_files = self._get_m300_parser().get_tune_files()
 
         return {
             "supported_events": events.SUPPORTED_EVENT_CATEGORIES,
@@ -231,13 +188,7 @@ class PwmBuzzerPlugin(
                 return
             self._printer.commands(gcode)
         else:
-            path = self._file_manager.path_on_disk("local", id)
-            file = open(path, "r")
-            lines = file.readlines()
-            commands = []
-            for line in lines:
-                if re.search(REGEX_LINE_HAS_M300_COMMAND, line, re.I) is not None:
-                    commands.append(line);
+            commands = self._get_m300_parser().get_tune_from_file(id)
             if len(commands) > 0:
                 self._printer.commands(commands)
             else:

--- a/octoprint_pwmbuzzer/__init__.py
+++ b/octoprint_pwmbuzzer/__init__.py
@@ -90,6 +90,7 @@ class PwmBuzzerPlugin(
             "supported_events": events.SUPPORTED_EVENT_CATEGORIES,
             "tune_presets": tunes.PRESETS,
             "tune_files": tune_files,
+            "needs_restart": self._get_m300_parser().needs_restart
         }
 
     def get_template_configs(self):

--- a/octoprint_pwmbuzzer/buzzers.py
+++ b/octoprint_pwmbuzzer/buzzers.py
@@ -30,6 +30,9 @@ class HardwareBuzzer(Buzzer):
         self._pwm = None
         self.set_settings(enabled, pin, duty_cycle)
 
+    def debug(self, enabled):
+        self._logger.setLevel(level=logging.DEBUG if enabled else logging.NOTSET)
+
     def Available():
         return GPIO_AVAILABLE
 
@@ -74,6 +77,9 @@ class SoftwareBuzzer(Buzzer):
 
         self._sendMessageImplementation = messageFunc
         self.set_settings(enabled)
+
+    def debug(self, enabled):
+        self._logger.setLevel(level=logging.DEBUG if enabled else logging.NOTSET)
 
     def set_settings(self, enabled):
         if enabled is not None:

--- a/octoprint_pwmbuzzer/files.py
+++ b/octoprint_pwmbuzzer/files.py
@@ -1,0 +1,75 @@
+from queue import SimpleQueue
+import re
+import time
+import logging
+
+REGEX_LINE_HAS_M300_COMMAND = r"^[^;]*M300"
+REGEX_FILE_HAS_ANY_M300_COMMAND = r"[m|M]300"
+REGEX_FILE_HAS_UNCOMMENTED_M300_COMMAND = r"(^[^;]*[m|M]300)|(\n[^;]*[m|M]300)"
+M300_ANALYSIS_KEY = "m300analysis"
+
+FILE_PARSE_WARN_AFTER = 3
+
+class M300FileParsingQueue():
+    def __init__(self, file_manager):
+        self._logger = logging.getLogger(__name__+"."+self.__class__.__name__)
+        self._file_manager = file_manager
+
+    def _filter_m300_files(self, file):
+        if file["type"] != "machinecode":
+            return False
+
+        id = file["path"]
+        fileHash = "default"
+        if "hash" in file:
+            fileHash = file["hash"]
+
+        if M300_ANALYSIS_KEY in file and fileHash in file[M300_ANALYSIS_KEY]:
+            return file[M300_ANALYSIS_KEY][fileHash]
+
+        path = self._file_manager.path_on_disk("local", id)
+        regex = re.compile(REGEX_FILE_HAS_ANY_M300_COMMAND)
+        with open(path, "r") as fileaccess:
+            text = fileaccess.read()
+            if re.search(regex, text):
+                regexu = re.compile(REGEX_FILE_HAS_UNCOMMENTED_M300_COMMAND)
+                if re.search(regexu, text):
+                    self._file_manager._storage_managers["local"].set_additional_metadata(path=id, key=M300_ANALYSIS_KEY, data=dict([(fileHash, True)]), merge=True)
+                    return True
+
+        self._file_manager._storage_managers["local"].set_additional_metadata(path=id, key=M300_ANALYSIS_KEY, data=dict([(fileHash, False)]), merge=True)
+        return False
+
+    def _recurse_files(self, folder, filelist = dict()):
+        for key in folder["children"]:
+            if folder["children"][key]["type"] == "folder":
+               self._recurse_files(folder["children"][key], filelist)
+            else:
+                filelist[folder["children"][key]["path"]] = folder["children"][key]
+
+    def get_tune_files(self):
+        start_time = time.time()
+        tune_files = dict()
+        all_files = self._file_manager._storage_managers["local"].list_files(filter=self._filter_m300_files)
+        if all_files is not None:
+            for key in all_files:
+                if all_files[key]["type"] == "folder":
+                    self._recurse_files(all_files[key], tune_files) 
+                else:
+                    tune_files[all_files[key]["path"]] = all_files[key]
+
+        elapsed = time.time() - start_time
+        if elapsed > FILE_PARSE_WARN_AFTER:
+            self._logger.warn("Parsing .gcode files for M300 content took %s seconds at startup" % elapsed)
+
+        return tune_files
+
+    def get_tune_from_file(self, filename):
+        path = self._file_manager.path_on_disk("local", filename)
+        file = open(path, "r")
+        lines = file.readlines()
+        commands = []
+        for line in lines:
+            if re.search(REGEX_LINE_HAS_M300_COMMAND, line, re.I) is not None:
+                commands.append(line);
+        return commands

--- a/octoprint_pwmbuzzer/templates/pwmbuzzer_settings.jinja2
+++ b/octoprint_pwmbuzzer/templates/pwmbuzzer_settings.jinja2
@@ -6,6 +6,9 @@
             <li class="active"><a href="#tabConfiguration" data-toggle="tab">{{ _('Configuration') }}</a></li>
             <li><a href="#tabEvents" data-toggle="tab">{{ _('Events') }}</a></li>
             <li><a href="#tabComposer" data-toggle="tab">{{ _('Composer') }}</a></li>
+            {% if plugin_pwmbuzzer_debug -%}
+                <li><a href="#tabDebug" data-toggle="tab">{{ _('Debug') }}</a></li>
+            {% endif %}
         </ul>
         <div class="tab-content">
             <div class="tab-pane active" id="tabConfiguration">
@@ -19,6 +22,12 @@
             <div class="tab-pane" id="tabComposer">
                 {%  include "settings/composer.jinja2" %}
             </div>
+
+            {% if plugin_pwmbuzzer_debug -%}
+                <div class="tab-pane" id="tabDebug">
+                    {%  include "settings/debug.jinja2" %}
+                </div>
+            {% endif %}
         </div>
     </div>
 </form>

--- a/octoprint_pwmbuzzer/templates/settings/debug.jinja2
+++ b/octoprint_pwmbuzzer/templates/settings/debug.jinja2
@@ -1,0 +1,7 @@
+<legend>{{ _('Debug Options') }}</legend>
+
+<div class="control-group">
+    <div class="controls">
+        <a class="btn btn-danger" href="#" data-bind="click: function() { issueToneCommand('debug_clear_metadata'); new PNotify({ title: 'Metadata cleared', text: 'Restart OctoPrint to repopulate it', type: 'warning', hide: true}); }"><i class="icon-remove"></i> {{ _('Clear File M300 Analysis Metadata') }}</a>
+    </div>
+</div>

--- a/octoprint_pwmbuzzer/templates/settings/events.jinja2
+++ b/octoprint_pwmbuzzer/templates/settings/events.jinja2
@@ -27,6 +27,13 @@
 </div>
 {%- endmacro %}
 
+{% if plugin_pwmbuzzer_needs_restart -%}
+    <div class="alert alert-block">
+        <strong>Warning: </strong>
+        Files are being processed in the background.  If you don't see a .gcode file that contains M300 commands in one of the drop-downs below, wait a few minutes and then restart OctoPrint.
+    </div>
+{% endif %}
+
 {% for group in plugin_pwmbuzzer_supported_events -%}
     <legend>{{ _(group.category) }}</legend>
     {% for event in group.events -%}

--- a/octoprint_pwmbuzzer/tones.py
+++ b/octoprint_pwmbuzzer/tones.py
@@ -13,8 +13,10 @@ class ToneCommand(Enum):
     REST = 3
 
 class Tone():
-    def __init__(self, command, buzzers = [], frequency = None, duration = None):
+    def __init__(self, command, buzzers = [], frequency = None, duration = None, debug = False):
         self._logger = logging.getLogger(__name__+"."+self.__class__.__name__)
+        self._logger.setLevel(level=logging.DEBUG if debug else logging.NOTSET)
+
         self.command = command
         self.buzzers = buzzers
         self.frequency = frequency
@@ -54,6 +56,9 @@ class ToneQueue():
         self._logger = logging.getLogger(__name__+"."+self.__class__.__name__)
         self._queue = SimpleQueue()
         self._thread = None
+
+    def debug(self, enabled):
+        self._logger.setLevel(level=logging.DEBUG if enabled else logging.NOTSET)
 
     def add(self, tone):
         self._logger.debug("adding to the queue: {0}".format(tone))


### PR DESCRIPTION
## Description

As with PR #3, I want to make sure that we don't block OctoPrint's main thread when we're parsing all of the files to see which contain M300 commands.  The file access was blocking, so on older hardware with lots of .gcode files uploaded the UI could stall before successfully loading for a few minutes (appears "stuck" even though it's just blocked temporarily).  These changes:

- Decouple file parsing logic from the main plugin class.
- Added a queue for parsing through files one-by-one.  When the queue is populated a new thread is spun up so that these are now parsed asynchronously.
- Added a warning message to the Events settings panel if any files are queued for processing... since we no longer block, the files won't be populated in this panel on first launch so the message lets users know they can try restarting the server after a bit.
- Added a debug config (not exposed) for additional logging and an easy way to clear M300 Analysis metadata for quicker testing.

## Screenshot of Debug Panel
<img width="982" alt="image" src="https://user-images.githubusercontent.com/15853840/161653174-233c59eb-b50f-43d2-b7e6-0dba28c8d9d8.png">

## Test Plan

- [x] verified a warning message appears in the Events panel on the first launch (when no metadata was stored)
- [x] verified custom gcode files appear in the Events drop-downs after parsing and restarting the server
- [x] verified functionality of the file parsing still works as expected, otherwise
- [x] verified an older Raspberry Pi 2B now loads the UI quickly with this change in place
- [x] added a debug panel and button for clearing out metadata to "reset" the file parsing state for quicker testing
