### PR TITLE
file errors (fixes #5), alerts, and confirms using PNotify

### DIFF
--- a/octoprint_pwmbuzzer/__init__.py
+++ b/octoprint_pwmbuzzer/__init__.py
@@ -208,6 +208,13 @@ class PwmBuzzerPlugin(
                 self._printer.commands(commands)
             else:
                 self._logger.warn("Tried to play tune from '{id}' but no M300 commands were detected.".format(**locals()))
+                self.sendMessageToFrontend({
+                    "action": "alert",
+                    "text": "Invalid tune '%s', no M300 commands detected - please check your plugin settings." % id,
+                    "type": "error",
+                    "hide": False,
+                    "launch_to_settings_tab": "#tabEvents"
+                })
 
     def handle_tone_command(self, cmd, frequency = None, duration = None):
         if frequency is None:

--- a/octoprint_pwmbuzzer/__init__.py
+++ b/octoprint_pwmbuzzer/__init__.py
@@ -180,6 +180,12 @@ class PwmBuzzerPlugin(
                 self._logger.error("Tried to clear M300 metadata while not in debug mode")
                 return
             self._get_m300_parser().debug_clear_metadata()
+            self.sendMessageToFrontend({
+                "action": "alert",
+                "text": "Metadata cleared.  Restart OctoPrint to repopulate it.",
+                "type": "warning",
+                "restart": True
+            })
 
     ##~~ Frontend Message Sending Helper
     def sendMessageToFrontend(self, params):

--- a/octoprint_pwmbuzzer/files.py
+++ b/octoprint_pwmbuzzer/files.py
@@ -127,7 +127,6 @@ class M300FileParsingQueue():
                 self._logger.debug("Cleared M300 Analysis metadata for: %s" % folder["children"][key]["path"])
 
     def debug_clear_metadata(self):
-        tune_files = dict()
         all_files = self._file_manager._storage_managers["local"].list_files()
         if all_files is not None:
             for key in all_files:
@@ -136,5 +135,4 @@ class M300FileParsingQueue():
                 else:
                     self._file_manager._storage_managers["local"].remove_additional_metadata(path=all_files[key]["path"], key=M300_ANALYSIS_KEY)
                     self._logger.debug("Cleared M300 Analysis metadata for: %s" % all_files[key]["path"])
-
-        return tune_files
+        return

--- a/octoprint_pwmbuzzer/files.py
+++ b/octoprint_pwmbuzzer/files.py
@@ -96,20 +96,26 @@ class M300FileParsingQueue():
 
     def file_has_tune(self, filename):
         path = self._file_manager.path_on_disk("local", filename)
-        file = open(path, "r")
-        for line in file.readlines():
-            if re.search(self._has_m300_regex, line) is not None:
-                return True
+        try:
+            file = open(path, "r")
+            for line in file.readlines():
+                if re.search(self._has_m300_regex, line) is not None:
+                    return True
+        except Exception as e:
+            self._logger.warn("Error reading '{0}': {1}".format(filename, e))
         return False
 
     def get_tune_from_file(self, filename):
         path = self._file_manager.path_on_disk("local", filename)
-        file = open(path, "r")
-        lines = file.readlines()
         commands = []
-        for line in lines:
-            if re.search(self._has_m300_regex, line) is not None:
-                commands.append(line);
+        try:
+            file = open(path, "r")
+            lines = file.readlines()
+            for line in lines:
+                if re.search(self._has_m300_regex, line) is not None:
+                    commands.append(line);
+        except Exception as e:
+            self._logger.warn("Error reading '{0}': {1}".format(filename, e))
         return commands
 
     def _recurse_clear(self, folder):

--- a/octoprint_pwmbuzzer/static/js/pwmbuzzer.js
+++ b/octoprint_pwmbuzzer/static/js/pwmbuzzer.js
@@ -139,6 +139,18 @@ $(function() {
                             }
                         );
                     }
+                    if (!!data.restart) {
+                        confirm.confirm = true;
+                        confirm.buttons.push(
+                            {
+                                text: "Restart",
+                                click: function(notice) {
+                                    OctoPrint.system.executeCommand("core", "restart");
+                                    notice.remove();
+                                }
+                            }
+                        );
+                    }
                     new PNotify({
                         title: "M300 PWM Buzzer Plugin",
                         text: data.text || "",

--- a/octoprint_pwmbuzzer/templates/settings/debug.jinja2
+++ b/octoprint_pwmbuzzer/templates/settings/debug.jinja2
@@ -2,6 +2,6 @@
 
 <div class="control-group">
     <div class="controls">
-        <a class="btn btn-danger" href="#" data-bind="click: function() { issueToneCommand('debug_clear_metadata'); new PNotify({ title: 'Metadata cleared', text: 'Restart OctoPrint to repopulate it', type: 'warning', hide: true}); }"><i class="icon-remove"></i> {{ _('Clear File M300 Analysis Metadata') }}</a>
+        <a class="btn btn-danger" href="#" data-bind="click: function() { issueToneCommand('debug_clear_metadata'); }"><i class="icon-remove"></i> {{ _('Clear File M300 Analysis Metadata') }}</a>
     </div>
 </div>

--- a/octoprint_pwmbuzzer/templates/settings/events.jinja2
+++ b/octoprint_pwmbuzzer/templates/settings/events.jinja2
@@ -4,7 +4,7 @@
     <div class="controls">
         <div class="btn-group gcode-actions-group">
             <a class="btn btn-warning" href="#" data-bind="click: function() { testEventTune('{{id}}') }"><i class="icon-music icon-white"></i> {{ _('Try it') }}</a>
-            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#">
+            <a class="btn dropdown-toggle" data-toggle="dropdown" href="#" data-bind="css: { 'btn-danger': {{plugin_pwmbuzzer_tune_presets|list + plugin_pwmbuzzer_tune_files|list}}.indexOf(events.{{ id }}.id())  === -1 }">
                 {% for preset_id, preset in plugin_pwmbuzzer_tune_presets.items() -%}
                     <span data-bind="visible: events.{{ id }}.id() == '{{preset_id}}'">{{ preset.name }}</span>
                 {% endfor %}
@@ -13,13 +13,13 @@
             </a>
             <ul class="dropdown-menu">
                 {% for preset_id, preset in plugin_pwmbuzzer_tune_presets.items() -%}
-                    <li><a href="#" data-bind="click: function() { setEventTune('{{id}}', '{{preset_id}}') }">{{ preset.name }}</a></li>
+                    <li data-bind="css: { active: events.{{ id }}.id() == '{{preset_id}}' }"><a href="#" data-bind="click: function() { setEventTune('{{id}}', '{{preset_id}}') }">{{ preset.name }}</a></li>
                 {% endfor %}
                 {% if plugin_pwmbuzzer_tune_files|length > 0 -%}
                     <li class="divider"></li>
                 {% endif %}
                 {% for tune_id in plugin_pwmbuzzer_tune_files -%}
-                    <li><a href="#" data-bind="click: function() { setEventTune('{{id}}', '{{tune_id}}') }"><i class="icon-file-alt"></i> {{ tune_id }}</a></li>
+                    <li data-bind="css: { active: events.{{ id }}.id() == '{{tune_id}}' }"><a href="#" data-bind="click: function() { setEventTune('{{id}}', '{{tune_id}}') }"><i class="icon-file-alt"></i> {{ tune_id }}</a></li>
                 {% endfor %}
             </ul>
         </div>


### PR DESCRIPTION
## Description

This set of changes were primarily made to address issue #5 by letting the user know if a tune file is missing (or invalid, containing no M300 commands) when it tries to use it.  File errors are now handled, and on the frontend the user is shown an error message that also provides a link into the plugin's settings Events panel.  Within the panel we'll now indicate any files that were not found to help make this easier to resolve:

<img width="330" alt="image" src="https://user-images.githubusercontent.com/15853840/162485111-2919f2a5-daab-476f-9e42-67255f8ea662.png">
<img width="981" alt="image" src="https://user-images.githubusercontent.com/15853840/162485263-d776adcc-2f50-4fbf-983c-17f9ff00d09c.png">

In addition, any place I previously used a standard javascript `alert`, `confirm`, or `prompt` have now been replaced with the more common PNotify alerts.

## Test Plan

- [x] verified a renamed or deleted .gcode file is now handled more gracefully, and within the client provides users a means of identifying which event is linked to a missing file
- [x] verified confirmation interactions (confirmation and cancel) for clearing or overwriting compositions in the settings Composer panel
- [x] verified prompt interactions (submit and cancel) for providing a filename on save or download of a composition in the settings Composer panel
- [x] verified functionality of the "restart" button added to the alert after using the "Clear File M300 Analysis Metadata" option in the settings Debug panel