### PR TITLE
#8: add option to suppress sending of m300 commands to printer

### DIFF
--- a/octoprint_pwmbuzzer/__init__.py
+++ b/octoprint_pwmbuzzer/__init__.py
@@ -32,6 +32,7 @@ class PwmBuzzerPlugin(
         self.sw_buzzer = None
 
         self._m300_parser = None
+        self._suppress_m300 = False
 
     def _get_m300_parser(self):
         if self._m300_parser is None:
@@ -58,6 +59,7 @@ class PwmBuzzerPlugin(
             self.sendMessageToFrontend,
             self._settings.get_boolean(["software_tone", "enabled"]),
         )
+        self._suppress_m300 = self._settings.get_boolean(["hardware_tone", "suppress_m300_passthrough"])
 
         debugEnabled = self._settings.get_boolean(["debug"])
         self.hw_buzzer.debug(debugEnabled)
@@ -75,6 +77,7 @@ class PwmBuzzerPlugin(
         self.sw_buzzer.set_settings(
             self._settings.get_boolean(["software_tone", "enabled"])
         )
+        self._suppress_m300 = self._settings.get_boolean(["hardware_tone", "suppress_m300_passthrough"])
 
     def _get_active_buzzers(self):
         return [buzzer for buzzer in [self.hw_buzzer, self.sw_buzzer] if buzzer is not None and buzzer.is_enabled()]
@@ -174,6 +177,7 @@ class PwmBuzzerPlugin(
                 self.sw_buzzer.set_settings(
                     data["sw"].get("enabled")
                 )
+            self._suppress_m300 = bool(data["hw"].get("suppress_m300"))
         
         elif command == "debug_clear_metadata":
             if not self._settings.get_boolean(["debug"]):
@@ -193,9 +197,11 @@ class PwmBuzzerPlugin(
 
     ##~~ GCode Phase hook
 
-    def sent_m300(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
+    def sending_m300(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
         if gcode and gcode.upper() == "M300":
             self.handle_tone_command(cmd)
+            if self._suppress_m300:
+                return None,  # don't send it on to the printer, return 1-tuple of None to suppress
 
     ##~~ Tone Helpers
 
@@ -256,5 +262,5 @@ def __plugin_load__():
     global __plugin_hooks__
     __plugin_hooks__ = {
         "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
-        "octoprint.comm.protocol.gcode.sent": __plugin_implementation__.sent_m300
+        "octoprint.comm.protocol.gcode.sending": __plugin_implementation__.sending_m300
     }

--- a/octoprint_pwmbuzzer/__init__.py
+++ b/octoprint_pwmbuzzer/__init__.py
@@ -66,6 +66,7 @@ class PwmBuzzerPlugin(
         self.tones.debug(debugEnabled)
 
     def on_settings_save(self, data):
+        octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
         self.hw_buzzer.set_settings(
             self._settings.get_boolean(["hardware_tone", "enabled"]),
             self._settings.get_int(["hardware_tone", "gpio_pin"]),
@@ -74,7 +75,6 @@ class PwmBuzzerPlugin(
         self.sw_buzzer.set_settings(
             self._settings.get_boolean(["software_tone", "enabled"])
         )
-        return octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
 
     def _get_active_buzzers(self):
         return [buzzer for buzzer in [self.hw_buzzer, self.sw_buzzer] if buzzer is not None and buzzer.is_enabled()]

--- a/octoprint_pwmbuzzer/settings.py
+++ b/octoprint_pwmbuzzer/settings.py
@@ -3,6 +3,7 @@ DEFAULT_SETTINGS = {
         "enabled": False,
         "gpio_pin": 16,
         "duty_cycle": 50,
+        "suppress_m300_passthrough": False,
     },
     "software_tone": {
         "enabled": True,

--- a/octoprint_pwmbuzzer/static/js/pwmbuzzer.js
+++ b/octoprint_pwmbuzzer/static/js/pwmbuzzer.js
@@ -30,6 +30,7 @@ $(function() {
         self.hw_enabled = ko.observable();
         self.hw_gpio_pin = ko.observable();
         self.hw_duty_cycle = ko.observable();
+        self.hw_suppress_m300 = ko.observable();
         self.sw_enabled = ko.observable();
         self.sw_volume = ko.observable();
         self.default_frequency = ko.observable();
@@ -108,7 +109,8 @@ $(function() {
                 hw: {
                     enabled: self.hw_enabled(),
                     pin: self.hw_gpio_pin(),
-                    duty_cycle: self.hw_duty_cycle()
+                    duty_cycle: self.hw_duty_cycle(),
+                    suppress_m300: self.hw_suppress_m300()
                 },
                 sw: {
                     enabled: self.sw_enabled()
@@ -182,6 +184,7 @@ $(function() {
             self.settings.hardware_tone.enabled(self.hw_enabled());
             self.settings.hardware_tone.gpio_pin(self.hw_gpio_pin());
             self.settings.hardware_tone.duty_cycle(self.hw_duty_cycle());
+            self.settings.hardware_tone.suppress_m300_passthrough(self.hw_suppress_m300());
             self.settings.default_tone.frequency(self.default_frequency());
             self.settings.default_tone.duration(self.default_duration());
             self.settings.software_tone.enabled(self.sw_enabled());
@@ -208,6 +211,7 @@ $(function() {
             self.hw_enabled(self.settings.hardware_tone.enabled());
             self.hw_gpio_pin(self.settings.hardware_tone.gpio_pin());
             self.hw_duty_cycle(self.settings.hardware_tone.duty_cycle());
+            self.hw_suppress_m300(self.settings.hardware_tone.suppress_m300_passthrough());
             self.default_frequency(self.settings.default_tone.frequency());
             self.default_duration(self.settings.default_tone.duration());
             self.sw_enabled(self.settings.software_tone.enabled());

--- a/octoprint_pwmbuzzer/templates/settings/configuration.jinja2
+++ b/octoprint_pwmbuzzer/templates/settings/configuration.jinja2
@@ -63,6 +63,15 @@
     </div>
 </div>
 
+<div class="control-group">
+    <div class="controls">
+        <label class="checkbox">
+            <input type="checkbox" data-bind="checked: hw_suppress_m300"> {{ _('Suppress M300 command passthrough') }}
+            <span class="help-block">{{ _('If your printer supports M300 commands but you want to use a passive buzzer instead (or just disable them), use this option to prevent the M300 commands from being sent to the printer.') }}</span>
+        </label>
+    </div>
+</div>
+
 <legend>{{ _('Software Buzzer') }}</legend>
 
 <div class="control-group">


### PR DESCRIPTION
## Description

@andritolion had a great suggestion for adding the ability to suppress M300 commands so that they could use a GPIO passive buzzer _instead_ of the active buzzer built into their printer.  I added a setting for this, but did not tie it to the enablement of a hardware buzzer (GPIO) so that, in theory, you could also just disable the handling of M300 commands on your printer altogether.

I also noticed a bug when settings are saved, options get updated to the old settings instead of the new changes.  This has been mitigated, making it easier (less confusing?) to test the M300 suppression changes.

## Screenshot
<img width="977" alt="image" src="https://user-images.githubusercontent.com/15853840/164751397-890f2dd5-1721-4eea-972a-7f162876c0cd.png">

## Test Plan

These changes can be tested by installing the plugin from: https://github.com/stealthmonkey99/OctoPrint-PWMBuzzer/archive/suppress-m300.zip

- [x] verified settings now apply properly when saved.  E.g. when disabling or enabling the software buzzer, it takes effect immediately after saving the settings
- [x] verified that when the new "Suppress M300 command passthrough" option is checked, no M300 commands show as sent in the octoprint console, but the software buzzer still handles and plays the tones
- [x] verified that when the new "Suppress M300 command passthrough" option is unchecked, M300 commands show as sent in the octoprint console (forwarded on to the printer as they were previously), and the software buzzer handles and plays the tones