### PR TITLE
#10: queue M300 tones even when printer is disconnected

### DIFF
--- a/octoprint_pwmbuzzer/__init__.py
+++ b/octoprint_pwmbuzzer/__init__.py
@@ -114,7 +114,7 @@ class PwmBuzzerPlugin(
             if (tune is None or tune == tunes.NO_SELECTION_ID or (payload is not None and "path" in payload and payload["path"] == tune)):
                 return
             self._logger.info("✅ '{event}' event fired, playing tune '{tune}'".format(**locals()))
-            self.play_tune(tune)
+            self.play_tune(tune, event in events.OFFLINE_EVENTS)
 
     ##~~ Softwareupdate hook
 
@@ -205,7 +205,7 @@ class PwmBuzzerPlugin(
 
     ##~~ Tone Helpers
 
-    def play_tune(self, id):
+    def play_tune(self, id, force_play_offline = False):
         if id is None or id == tunes.NO_SELECTION_ID:
             return
 
@@ -226,7 +226,7 @@ class PwmBuzzerPlugin(
                 })
                 return
 
-        if self._printer.is_closed_or_error():
+        if self._printer.is_closed_or_error() or force_play_offline:
             # if the printer is disconnected, just queue up the commands for playback off-printer
             for cmd in gcode:
                 self.handle_tone_command(cmd)

--- a/octoprint_pwmbuzzer/events.py
+++ b/octoprint_pwmbuzzer/events.py
@@ -1,20 +1,34 @@
-SUPPORTED_EVENTS = ["Startup", "Shutdown", "ClientOpened", "Connected", "PrintStarted", "PrintDone", "PrintFailed", "PrintPaused", "PrintResumed", "PrintCancelled", "FileAdded", "FileRemoved"]
+SUPPORTED_EVENTS = ["Startup", "Shutdown", "ClientOpened", "ClientClosed", "Connected", "Disconnected", "PrintStarted", "PrintDone", "PrintFailed", "PrintPaused", "PrintResumed", "PrintCancelled", "FileAdded", "FileRemoved"]
+
+OFFLINE_EVENTS = ["Startup", "Shutdown", "Connected", "Disconnected"]
 
 SUPPORTED_EVENT_CATEGORIES = [
     {
         "category": "System Events",
         "events": [
             {
-                "id": "Connected",
-                "name": "Startup (Printer Connected)"
+                "id": "Startup",
+                "name": "Startup"
             },
             {
                 "id": "Shutdown",
                 "name": "Shutdown"
             },
             {
+                "id": "Connected",
+                "name": "Printer Connected"
+            },
+            {
+                "id": "Disconnected",
+                "name": "Printer Disconnected"
+            },
+            {
                 "id": "ClientOpened",
                 "name": "OctoPrint Client Connected"
+            },
+            {
+                "id": "ClientClosed",
+                "name": "OctoPrint Client Disconnected"
             }
         ]
     },

--- a/octoprint_pwmbuzzer/settings.py
+++ b/octoprint_pwmbuzzer/settings.py
@@ -15,9 +15,12 @@ DEFAULT_SETTINGS = {
         "duration": 1000,
     },
     "events": {
-        "Connected": ":PRESET:SLIDEUP",
+        "Startup": ":PRESET:SLIDEUP",
         "Shutdown": ":PRESET:SLIDEDOWN",
+        "Connected": ":PRESET:NONE",
+        "Disconnected": ":PRESET:NONE",
         "ClientOpened": ":PRESET:NONE",
+        "ClientClosed": ":PRESET:NONE",
         "PrintStarted": ":PRESET:NONE",
         "PrintDone": ":PRESET:LG",
         "PrintFailed": ":PRESET:SIREN",

--- a/octoprint_pwmbuzzer/static/js/composer.js
+++ b/octoprint_pwmbuzzer/static/js/composer.js
@@ -96,7 +96,7 @@ function M300Composer(parent) {
     }
 
     self.play = function() {
-        if (self.isEmpty()) { return; }
+        if (self.isEmpty() || !parentVM.printerConnected()) { return; }
 
         OctoPrint.control.sendGcode(self.data());
     }

--- a/octoprint_pwmbuzzer/static/js/pwmbuzzer.js
+++ b/octoprint_pwmbuzzer/static/js/pwmbuzzer.js
@@ -36,6 +36,7 @@ $(function() {
         self.default_frequency = ko.observable();
         self.default_duration = ko.observable();
         self.events = {};
+        self.printerConnected = ko.observable(false);
 
         self.sw_buzzer = new SoftwareBuzzer(self);
         self.composer = new M300Composer(self);
@@ -196,6 +197,16 @@ $(function() {
 
         self.onSettingsHidden = function() {
             self.resetLocalSettings();
+        }
+
+        self.onSettingsShown = function() {
+            OctoPrint.printer.getFullState()
+                .then(function(result) {
+                    self.printerConnected(!result.state.flags.closedOrError);
+                })
+                .catch(function(error) {
+                    self.printerConnected(false);
+                });
         }
 
         self.initSettings = function() {

--- a/octoprint_pwmbuzzer/templates/settings/composer.jinja2
+++ b/octoprint_pwmbuzzer/templates/settings/composer.jinja2
@@ -33,7 +33,7 @@
         <a class="btn btn-small" href="#" id="edit-cleanup" data-bind="click: function(_, event) { edit('cleanup', event) }, css: { disabled: isEmpty }"><i class="icon-magic"></i> {{ _('Snap Durations') }}</a>
         <a class="btn btn-small" href="#" id="edit-clear" data-bind="click: function(_, event) { edit('clear', event) }, css: { disabled: isEmpty }"><i class="icon-trash"></i> {{ _('Clear') }}</a>
         <div class="btn-group gcode-actions-group">
-            <a class="btn btn-small btn-primary" href="#" data-bind="click: play, css: { disabled: isEmpty }"><i class="icon-music icon-white"></i> {{ _('Send Gcode to Printer') }}</a>
+            <a class="btn btn-small btn-primary" href="#" data-bind="click: play, css: { disabled: isEmpty() || !$parent.printerConnected() }"><i class="icon-music icon-white"></i> {{ _('Send Gcode to Printer') }}</a>
             <a class="btn btn-small btn-primary dropdown-toggle" data-toggle="dropdown" href="#" data-bind="css: { disabled: isEmpty }"><span class="caret"></span></a>
             <ul class="dropdown-menu dropdown-menu-right">
                 <li><a class="btn-small" href="#" data-bind="click: save, css: { disabled: isEmpty }"><i class="icon-save"></i> {{ _('Save Gcode File') }}</a></li>


### PR DESCRIPTION
## Description

Previously, playing tunes - such as those triggered by events - worked by sending M300 commands to the printer queue.  This means a tune might not play if a printer is not actively connected and accepting gcode.  Issue #10 describes the "test" buttons in the Events settings panel not working when the printer is disconnected.  Another example would be the following repro steps:

1. disconnect all printers (including virtual)
2. set an event to trigger a tune when a file is added
3. upload a file

**EXPECTED**: tune plays after the file uploads
**ACTUAL**: since a printer isn't connected, the M300 commands get dropped and the tune does not play

This change:
- looks for an active printer connection before sending gcode to it
- queues up sounds _without_ sending them to the printer if it is disconnected
- disables the "Send Gcode to Printer" button in the composer tab if the printer isn't connected
- forces queuing tunes for certain events (specifically, those that are likely to occur when a printer is not connected) so that we can still hear them on a GPIO buzzer even when the printer connection is not active
- Startup (server, not printer), Printer Disconnected, and Client Disconnected events were added to the Events settings panel

## Test Plan

These changes can be tested by installing the plugin from: https://github.com/stealthmonkey99/OctoPrint-PWMBuzzer/archive/disconnected-play.zip

- [x] verified functionality of Startup, Shutdown, Printer Connected, Printer Disconnected, Client Connected, and Client Disconnected events with a GPIO buzzer enabled
- [x] verified the ability to test tunes even when a real printer is disconnected
- [x] verified the ability to test tunes even when a virtual printer is disconnected
- [x] ensure "Send gcode to printer" button in composer is disabled and non-functional when printer is disconnected

Thanks to @andritolion for the bug report!