### PR TITLE
fix #13: wait for tone queue to play out on shutdown

### DIFF
--- a/octoprint_pwmbuzzer/__init__.py
+++ b/octoprint_pwmbuzzer/__init__.py
@@ -106,7 +106,7 @@ class PwmBuzzerPlugin(
     def get_template_configs(self):
         return []
 
-    ##~~ EventHandlerPlugin
+    ##~~ EventHandlerPlugin mixin
 
     def on_event(self, event, payload):
         if event in events.SUPPORTED_EVENTS:
@@ -114,7 +114,7 @@ class PwmBuzzerPlugin(
             if (tune is None or tune == tunes.NO_SELECTION_ID or (payload is not None and "path" in payload and payload["path"] == tune)):
                 return
             self._logger.info("✅ '{event}' event fired, playing tune '{tune}'".format(**locals()))
-            self.play_tune(tune, event in events.OFFLINE_EVENTS)
+            self.play_tune(tune, event in events.OFFLINE_EVENTS, event in events.BLOCKING_EVENTS)
 
     ##~~ Softwareupdate hook
 
@@ -205,7 +205,7 @@ class PwmBuzzerPlugin(
 
     ##~~ Tone Helpers
 
-    def play_tune(self, id, force_play_offline = False):
+    def play_tune(self, id, force_play_offline = False, wait_for_playback = False):
         if id is None or id == tunes.NO_SELECTION_ID:
             return
 
@@ -235,6 +235,8 @@ class PwmBuzzerPlugin(
             # ...otherwise, send the commands to the printer
             self._printer.commands(gcode)
 
+        if wait_for_playback:
+            self.tones.wait()
 
     def handle_tone_command(self, cmd, frequency = None, duration = None):
         if frequency is None:

--- a/octoprint_pwmbuzzer/events.py
+++ b/octoprint_pwmbuzzer/events.py
@@ -2,6 +2,8 @@ SUPPORTED_EVENTS = ["Startup", "Shutdown", "ClientOpened", "ClientClosed", "Conn
 
 OFFLINE_EVENTS = ["Startup", "Shutdown", "Connected", "Disconnected"]
 
+BLOCKING_EVENTS = ["Shutdown"]
+
 SUPPORTED_EVENT_CATEGORIES = [
     {
         "category": "System Events",

--- a/octoprint_pwmbuzzer/tones.py
+++ b/octoprint_pwmbuzzer/tones.py
@@ -5,6 +5,7 @@ import time
 import logging
 
 INTER_NOTE_PAUSE_DURATION = 0.01
+MAX_SHUTDOWN_WAIT = 3.0
 
 class ToneCommand(Enum):
     STOP = 0
@@ -64,6 +65,16 @@ class ToneQueue():
         self._logger.debug("adding to the queue: {0}".format(tone))
         self._queue.put(tone)
         self._runQueue()
+
+    def wait(self):
+        start_time = time.time()
+
+        if self._thread is not None:
+            self._thread.join(MAX_SHUTDOWN_WAIT)
+
+        elapsed = time.time() - start_time
+        status = "warning: thread still running" if self._thread is not None and self._thread.is_alive() else "thread completed"
+        self._logger.debug("waited %.4fsec for ToneQueue to execute (%s)" % (elapsed, status))
 
     def _runQueue(self):
         if self._thread is not None and self._thread.is_alive():


### PR DESCRIPTION
## Description

When testing #11 I realized that setting a tune on `Shutdown` resulted in only the first note being played before the rest was cut off.  Since playback was moved to a non-blocking thread, the tune no longer blocks on shutdown.  While we do NOT want to introduce long-running operations on shutdown, this change does wait up to 3 seconds for a tune to finish playing if one is triggered on the `Shutdown` event.  If the tune is longer than 3 seconds, it will be truncated at that point as the system continues to shut down and terminate the ToneQueue's worker thread.

## Test Plan

These changes can be tested by installing the plugin from: https://github.com/stealthmonkey99/OctoPrint-PWMBuzzer/archive/block-shutdown-tune.zip

- [x] verified functionality of Shutdown event with a GPIO buzzer enabled
- [x] tunes < ~3s play fully on shutdown, longer tunes are truncated after waiting a maximum of 3 seconds
- [x] debug logging shows that we're not waiting unnecessarily if we don't have a tune set for the Shutdown event or if the tune is shorter than 3sec