### PR TITLE
#18: fix for saving M300 suppression setting

### DIFF
--- a/octoprint_pwmbuzzer/static/js/pwmbuzzer.js
+++ b/octoprint_pwmbuzzer/static/js/pwmbuzzer.js
@@ -199,6 +199,7 @@ $(function() {
             self.settings.hardware_tone.enabled(!!self.hw_enabled());
             self.settings.hardware_tone.gpio_pin(parseInt(self.hw_gpio_pin()));
             self.settings.hardware_tone.duty_cycle(parseInt(self.hw_duty_cycle()));
+            self.settings.hardware_tone.suppress_m300_passthrough(!!self.hw_suppress_m300());
             self.settings.default_tone.frequency(parseFloat(self.default_frequency()));
             self.settings.default_tone.duration(parseInt(self.default_duration()));
             self.settings.software_tone.enabled(!!self.sw_enabled());


### PR DESCRIPTION
Fixing a regression that was caused when I mistakenly dropped the M300 suppression setting while fixing the typing on the other settings in [this commit](https://github.com/stealthmonkey99/OctoPrint-PWMBuzzer/commit/3e210a5c48b36d3082dbadd8e61f3179c3b43e73#diff-492f80fc0155cb4f5e01eaf596334e19f63d04b2dd9507eff12d9d2f6ca54ee2L190).