### PR TITLE
Add RuntimeError handling for non-RPi devices; Add another possible MIME type for MIDI importer

### DIFF
--- a/octoprint_pwmbuzzer/buzzers.py
+++ b/octoprint_pwmbuzzer/buzzers.py
@@ -6,7 +6,7 @@ try:
     import RPi.GPIO as GPIO
     from rpi_hardware_pwm import HardwarePWM
     GPIO_AVAILABLE = True
-except ImportError:
+except (ImportError, RuntimeError):
     GPIO_AVAILABLE = False
 
 OVERLAY_CONFIG_12 = "dtoverlay=pwm,pin=12,func=4"

--- a/octoprint_pwmbuzzer/static/js/midi/constants.js
+++ b/octoprint_pwmbuzzer/static/js/midi/constants.js
@@ -1,4 +1,4 @@
-MIDI_TYPES = [".rmi", "audio/midi", "audio/x-midi"];
+MIDI_TYPES = [".rmi", "audio/mid", "audio/midi", "audio/x-midi"];
 
 MIDI_IMPORT_CANCEL = "MIDI_IMPORT_CANCEL";
 


### PR DESCRIPTION
I was gonna fire two pull requests for those two issues. However for some reason GitHub added my two commits into a single pull request and I can't find where to revert the second commit so guess I'll leave it like so.

When installing the plugin on non Raspberry Pi devices (for usage with software buzzer mostly), the RPi.GPIO library will throw out a `RuntimeError: Not running on a RPi!` when imported. This is not handled by the plugin causing load failure.

Also when importing a MIDI file on the latest Chrome, it gives a `Wrong file type` error dialog. When inspecting the MIME type field of the uploaded file, it's `audio/mid` instead of `audio/midi`.